### PR TITLE
Add quick setup

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -20,7 +20,29 @@
 - [mise](https://mise.jdx.dev/) (推奨)
 - [uv](https://docs.astral.sh/uv/) (推奨)
 
-## インストール
+## クイックスタート
+
+### 1. リポジトリのクローン
+
+```bash
+git clone https://github.com/anosatsuk124/jujutsu-summarize-hook.git
+```
+
+### 2. インストール
+
+```bash
+cd jujutsu-summarize-hook
+uv tool install .
+```
+```
+
+### 3. 好きな場所にhooks/agents のインストール (ローカルディレクトリ)
+
+```bash
+jj-hook install-all
+```
+
+## インストール (開発者向け)
 
 ### 1. プロジェクトのセットアップ
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,34 @@ This repository provides AI-powered hooks for Claude Code that integrate with th
 ## Requirements
 
 - Python 3.9+
+- [uv](https://docs.astral.sh/uv/)
 - [Jujutsu (jj)](https://github.com/martinvonz/jj)
 - [Claude Code](https://claude.ai/code)
 - [mise](https://mise.jdx.dev/) (recommended)
-- [uv](https://docs.astral.sh/uv/) (recommended)
 
-## Installation
+## Quick Start
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/anosatsuk124/jujutsu-summarize-hook.git
+```
+
+### 2. Installation
+
+```bash
+cd jujutsu-summarize-hook
+uv tool install .
+```
+```
+
+### 3. Use anywhere you want (hooks/agents installation in a local directory)
+
+```bash
+jj-hook install-all
+```
+
+## Installation for development
 
 ### 1. Project Setup
 


### PR DESCRIPTION
This pull request updates the documentation in both `README.md` and `README.ja.md` to improve clarity and provide a more structured guide for users. The changes include renaming the "Installation" section to "Quick Start," adding step-by-step instructions for cloning the repository, installing dependencies, and setting up hooks.

### Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R48): Renamed the "Installation" section to "Quick Start" and added detailed steps for cloning the repository, installing dependencies using `uv`, and installing hooks with `jj-hook`. Removed duplicate entries for `uv` in the requirements list.
* [`README.ja.md`](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L23-R45): Similar updates as in `README.md`, including renaming the "インストール" section to "クイックスタート" and adding step-by-step instructions in Japanese.